### PR TITLE
Add events resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ client.emails.send(
 )
 ```
 
+### Tracking events
+
+```ruby
+client.events.track(
+  event: "subscription_renewed",
+  user: "user@example.com",
+  properties: { plan: "pro", amount: 99 }
+)
+```
+
 ### Error handling
 
 ```ruby

--- a/lib/mailjunky.rb
+++ b/lib/mailjunky.rb
@@ -6,6 +6,7 @@ require_relative "mailjunky/configuration"
 require_relative "mailjunky/connection"
 require_relative "mailjunky/resources/base"
 require_relative "mailjunky/resources/emails"
+require_relative "mailjunky/resources/events"
 require_relative "mailjunky/client"
 
 module MailJunky

--- a/lib/mailjunky/client.rb
+++ b/lib/mailjunky/client.rb
@@ -2,7 +2,7 @@
 
 module MailJunky
   class Client
-    attr_reader :emails
+    attr_reader :emails, :events
 
     def initialize(api_key: nil, base_url: nil, timeout: nil, open_timeout: nil)
       config = Configuration.new
@@ -14,6 +14,7 @@ module MailJunky
       connection = Connection.new(config)
 
       @emails = Resources::Emails.new(connection)
+      @events = Resources::Events.new(connection)
     end
   end
 end

--- a/lib/mailjunky/resources/events.rb
+++ b/lib/mailjunky/resources/events.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module MailJunky
+  module Resources
+    class Events < Base
+      def track(event:, user: nil, properties: nil, session_id: nil, timestamp: nil)
+        payload = {
+          event: event,
+          user: user,
+          properties: properties,
+          session_id: session_id,
+          timestamp: timestamp
+        }.compact
+
+        connection.post("/api/v1/events/track", payload)
+      end
+    end
+  end
+end

--- a/spec/integration/events_spec.rb
+++ b/spec/integration/events_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Tracking events", type: :integration do
+  let(:client) { MailJunky::Client.new(api_key: "test_api_key") }
+
+  before do
+    stub_request(:post, "https://api.mailjunky.ai/api/v1/events/track")
+      .to_return(
+        status: 200,
+        body: { success: true, event_id: "evt_abc123" }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+
+  describe "client.events.track" do
+    it "tracks an event and returns the response" do
+      response = client.events.track(
+        event: "button_clicked",
+        user: "user@example.com",
+        properties: { button_id: "signup" }
+      )
+
+      expect(response["success"]).to be true
+      expect(response["event_id"]).to eq("evt_abc123")
+    end
+
+    it "makes the correct request" do
+      client.events.track(
+        event: "purchase_completed",
+        user: "buyer@example.com",
+        properties: { amount: 100, currency: "USD" }
+      )
+
+      expect(WebMock).to have_requested(:post, "https://api.mailjunky.ai/api/v1/events/track")
+        .with(
+          body: {
+            event: "purchase_completed",
+            user: "buyer@example.com",
+            properties: { amount: 100, currency: "USD" }
+          },
+          headers: { "Authorization" => "Bearer test_api_key" }
+        )
+    end
+  end
+end

--- a/spec/unit/resources/events_spec.rb
+++ b/spec/unit/resources/events_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe MailJunky::Resources::Events do
+  let(:connection) { instance_double(MailJunky::Connection) }
+  let(:events) { described_class.new(connection) }
+
+  describe "#track" do
+    it "posts to the track endpoint with required params" do
+      expect(connection).to receive(:post).with(
+        "/api/v1/events/track",
+        { event: "signup_completed" }
+      )
+
+      events.track(event: "signup_completed")
+    end
+
+    it "includes optional params when provided" do
+      expect(connection).to receive(:post).with(
+        "/api/v1/events/track",
+        {
+          event: "subscription_renewed",
+          user: "user@example.com",
+          properties: { plan: "pro", amount: 99 },
+          session_id: "sess_123",
+          timestamp: "2026-02-27T12:00:00Z"
+        }
+      )
+
+      events.track(
+        event: "subscription_renewed",
+        user: "user@example.com",
+        properties: { plan: "pro", amount: 99 },
+        session_id: "sess_123",
+        timestamp: "2026-02-27T12:00:00Z"
+      )
+    end
+
+    it "excludes nil values from payload" do
+      expect(connection).to receive(:post).with(
+        "/api/v1/events/track",
+        { event: "page_viewed", user: "user@example.com" }
+      )
+
+      events.track(event: "page_viewed", user: "user@example.com")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Add the events resource to track user events via the MailJunky API.

## Usage
```ruby
client.events.track(
  event: "subscription_renewed",
  user: "user@example.com",
  properties: { plan: "pro", amount: 99 }
)
```

## Closes
- Closes #1

## Test plan
- [x] Unit tests (3 specs)
- [x] Integration tests (2 specs)
- [x] All 40 specs passing
- [x] RuboCop clean